### PR TITLE
Fixed not splitting in some levels in the PC port

### DIFF
--- a/Spider-Man (2000)/Spider-Man_(2000)_Auto-Splitter.asl
+++ b/Spider-Man (2000)/Spider-Man_(2000)_Auto-Splitter.asl
@@ -530,8 +530,6 @@ update
 			}
 		}
 		
-		vars.dontStartUntilMainMenu = !(current.IsMainMenu == 1 && current.IsStartScreen == 0 && (current.DeathMenu != 3 || current.LevelID == 695));
-		
 		if (vars.dontSplitUntilPlaying) 
 		{ 
 			vars.dontSplitUntilPlaying = !(old.IsPlaying == 0 && current.IsPlaying == 1);
@@ -575,6 +573,8 @@ start
 {
 	if (vars.hasMenus)
 	{
+		vars.dontStartUntilMainMenu = !(current.IsMainMenu == 1 && current.IsStartScreen == 0 && (current.DeathMenu != 3 || current.LevelID == 695));
+		
 		if (!vars.dontStartUntilMainMenu)
 		{
 			if (vars.menuSelection[0] == 1 && vars.menuSelection[1] != -1)


### PR DESCRIPTION
Fixed the bug in which the auto splitter wasn't working properly in some levels of the PC port (Building Top Chase, Scale the Girders, Police Evaded, Spidey vs. Monster Ock). I did a quick check and the auto-start feature still works for the PS1 version and it doesn't start when the Credits are playing.